### PR TITLE
Improve yamllint and add phpunit parallel mode

### DIFF
--- a/configs/grumphp.yaml
+++ b/configs/grumphp.yaml
@@ -6,6 +6,7 @@ parameters:
     run_phpstan: false # Enable after installing the phpstan preset
     run_psalm: false # Enable after installing the psalm preset
     run_security_advisories: false # Enable after installing the security advisories preset
+    phpunit.parallel: true # Decide if it is possible to run phpunit tests in parallel or not.
 
     # Personal preferences
     stop_on_first_failure: false

--- a/grumphp-convention.yml
+++ b/grumphp-convention.yml
@@ -6,6 +6,7 @@ parameters:
     run_security_advisories: false
     grumhp_exec_command: kevin app php
     phpstan.level: "max"
+    phpunit.parallel: true
     phpstan.ignore:
         - "tests/"
         - "Tests/"
@@ -13,6 +14,8 @@ parameters:
         - "var/"
         - "src/Migrations/"
         - "spec/"
+    yaml.ignore:
+        - 'docker-compose.yml'
 grumphp:
     stop_on_failure: "%stop_on_first_failure%"
     git_hook_variables:
@@ -21,9 +24,15 @@ grumphp:
         enabled: true
         fix_by_default: true
     tasks:
-        paratest: ~
+        phpunit:
+            metadata:
+                enabled: "@=container.getParameter('phpunit.parallel') ? false : true"
+        paratest:
+            metadata:
+                enabled: "%phpunit.parallel%"
         yamllint:
             parse_custom_tags: true
+            ignore_patterns: "%yaml.ignore%"
         composer:
             strict: false
             no_check_publish: true

--- a/recipes/phpro.symfony-conventions.1.0.json
+++ b/recipes/phpro.symfony-conventions.1.0.json
@@ -19,6 +19,7 @@
                         "    run_phpstan: false # Enable after installing the phpstan preset",
                         "    run_psalm: false # Enable after installing the psalm preset",
                         "    run_security_advisories: false # Enable after installing the security advisories preset",
+                        "    phpunit.parallel: true # Decide if it is possible to run phpunit tests in parallel or not.",
                         "",
                         "    # Personal preferences",
                         "    stop_on_first_failure: false",
@@ -119,7 +120,7 @@
                     "executable": false
                 }
             },
-            "ref": "dd7925e6ba0fd1dbe6aad5dd3e3a0b86c9127da9"
+            "ref": "b44a63137600dea89be4ac5ed0f7dbd84305174a"
         }
     }
 }


### PR DESCRIPTION
* Improves yamllint (ignores docker-compose, since it cannot lint inheriting blocks yet)
* Add the ability to run phpunit in parallel or not (through paratest)