### PR TITLE
cs-fixer deprecation v3.18 "blank_lines_before_namespace" replaces "n…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.1",
         "brianium/paratest": "^6.3",
-        "php-cs-fixer/shim": "^3.7",
+        "php-cs-fixer/shim": "^3.18",
         "phpro/grumphp-shim": "^2.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/configs/.php-cs-fixer.php
+++ b/configs/.php-cs-fixer.php
@@ -44,7 +44,6 @@ return (new PhpCsFixer\Config())
         'multiline_whitespace_before_semicolons' => true,
         'native_function_invocation' => false,
         'no_alias_functions' => true,
-        'no_blank_lines_before_namespace' => false,
         'no_extra_blank_lines' => true,
         'no_null_property_initialization' => true,
         'no_php4_constructor' => true,

--- a/recipes/phpro.symfony-conventions.1.0.json
+++ b/recipes/phpro.symfony-conventions.1.0.json
@@ -75,7 +75,6 @@
                         "        'multiline_whitespace_before_semicolons' => true,",
                         "        'native_function_invocation' => false,",
                         "        'no_alias_functions' => true,",
-                        "        'no_blank_lines_before_namespace' => false,",
                         "        'no_extra_blank_lines' => true,",
                         "        'no_null_property_initialization' => true,",
                         "        'no_php4_constructor' => true,",
@@ -121,7 +120,7 @@
                     "executable": false
                 }
             },
-            "ref": "2e3f94013a1ceed3ca270ca92a9d3240c9dd4cbd"
+            "ref": "cf9cea7b7bed384e61df5472858f35170b28371f"
         }
     }
 }


### PR DESCRIPTION
Deprecations since version PHP CS Fixer 3.18 and higher
Best to apply the draft when the deprecated options are no longer supported or a higher version is a project requirement.

:warning: Minimum php-cs-fixer version updated to `php-cs-fixer/shim: ^3.18`

Rule changes
* `blank_lines_before_namespace` replaces `no_blank_lines_before_namespace`
   Config rule can be removed as `@PSR12` and `@Symfony` rulesets contain the default setting, 
   which is conform the deprecated `no_blank_lines_before_namespace => false,`