### PR TITLE
Activate composer audit by default (instead of roave security advisories)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,29 @@ composer recipes
 composer recipes:install THE/DEPENDENCY --force -v
 ```
 
-### roave/security-advisories 
-
-```bash
-composer require --dev roave/security-advisories:dev-master
-```
+### composer audit (security-advisories)
 
 ```yaml 
 # grumphp.yaml
 parameters:
     run_security_advisories: true
 ```
+
+You might want to alter the default composer audit configuration in your local composer.json file.
+
+For example if you don't want to fail CI on usage of abandoned packages:
+
+```json
+{
+    "config": {
+        "audit": {
+            "abandoned": "report"
+        }
+    }
+}
+```
+
+[See official docs for more information.](https://getcomposer.org/doc/06-config.md#audit)
 
 ### phpstan/phpstan
 

--- a/grumphp-convention.yml
+++ b/grumphp-convention.yml
@@ -3,7 +3,7 @@ parameters:
     stop_on_first_failure: false
     run_phpstan: false
     run_psalm: false
-    run_security_advisories: false
+    run_security_advisories: true
     grumhp_exec_command: kevin app php
     phpstan.level: "max"
     phpunit.parallel: true
@@ -61,9 +61,7 @@ grumphp:
         phpcsfixer:
             config: ".php-cs-fixer.php"
             config_contains_finder: true
-        securitychecker_roave:
-            jsonfile: ./composer.json
-            lockfile: ./composer.lock
+        securitychecker_composeraudit:
             run_always: true
             metadata:
                 enabled: "%run_security_advisories%"


### PR DESCRIPTION
See https://php.watch/articles/composer-audit

Composer audit works in a less blocking way than roave/security-advisories.
It can be used on all of our local development setups by default without having additional dependencies.


Changed:

* Moved to composer audit instead of roave/security advisories
* Enabled security check by default now that it does not require an additional 3rd party package.


Make sure you are on composer >2.4:

```sh
kevin composer self-update --stable
```

(Or upgrade to your latest PHP image with `kevin pull`)

You might want to avoid failing on usage of deprecated packages (if for example your framework relies on them):

```json5
// composer.json

{
    "config": {
        "audit": {
            "abandoned": "report"
        }
    }
}
```

